### PR TITLE
feat: Support ESLint 7.x

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,64 +5,74 @@ on:
   pull_request:
     branches: [master]
   schedule:
-  - cron: 0 0 * * 0
+    - cron: 0 0 * * 0
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
-    - name: Install Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12
-    - name: Install Packages
-      run: npm install
-    - name: Lint
-      run: npm run -s lint
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Install Packages
+        run: npm install
+      - name: Lint
+        run: npm run -s lint
 
   test:
     name: Test
     strategy:
       matrix:
-        node: [12, 10, 8, 6]
-        eslint: [6, 5]
-        exclude:
-        # ESLint 6 doesn't support Node 6.
-        - node: 6
-          eslint: 6
-        # Run ESLint 5 on only the newest and oldest Node.
-        - node: 10
-          eslint: 5
-        - node: 8
-          eslint: 5
-    runs-on: ubuntu-latest
+        os: [ubuntu-latest]
+        eslint: [7]
+        node: [14]
+        include:
+          # On other platforms
+          - eslint: 7
+            node: 14
+            os: windows-latest
+          - eslint: 7
+            node: 14
+            os: macos-latest
+          # On old Node.js versions
+          - eslint: 7
+            node: 12
+            os: ubuntu-latest
+          - eslint: 7
+            node: 10
+            os: ubuntu-latest
+          # On old ESLint versions
+          - eslint: 6
+            node: 14
+            os: ubuntu-latest
+          - eslint: 5
+            node: 14
+            os: ubuntu-latest
+          # On the minimum supported ESLint/Node.js version
+          - eslint: 5
+            node: 10
+            os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
-    - name: Install Node.js v${{ matrix.node }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node }}
-    - name: Install Packages
-      run: |
-        if [ ${{ matrix.node }} -eq 6 ]; then
-          npm install --global npm@^6.0.0
-        fi
-        npm install
-    - name: Install ESLint v${{ matrix.eslint }}
-      run: npm install --no-save eslint@^${{ matrix.eslint }}.0.0
-    - name: Build
-      run: npm run -s build
-    - name: Test
-      run: npm run -s test:mocha
-    - name: Send Coverage
-      run: npm run -s codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Node.js v${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install Packages
+        run: npm install
+      - name: Install ESLint ${{ matrix.eslint }}
+        run: npm install --no-save eslint@${{ matrix.eslint }}
+      - name: Build
+        run: npm run -s build
+      - name: Test
+        run: npm run -s test:mocha
+      - name: Send Coverage
+        run: npm run -s codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ npm install eslint-utils
 ```
 
 ::: tip Requirements
-`eslint-utils` requires Node.js `6.5.0` or newer versions.
+`eslint-utils` requires Node.js `10` or newer versions.
 :::
 
 ## 📖 Usage

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.0",
   "description": "Utilities for ESLint plugins.",
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   },
   "sideEffects": false,
   "main": "index",
@@ -12,15 +12,15 @@
     "index.*"
   ],
   "dependencies": {
-    "eslint-visitor-keys": "^1.1.0"
+    "eslint-visitor-keys": "^2.0.0"
   },
   "devDependencies": {
-    "@mysticatea/eslint-plugin": "^12.0.0",
+    "@mysticatea/eslint-plugin": "^13.0.0",
     "codecov": "^3.6.1",
     "dot-prop": "^4.2.0",
-    "eslint": "^6.5.1",
+    "eslint": "^7.24.0",
     "esm": "^3.2.25",
-    "espree": "^6.1.1",
+    "espree": "^7.3.1",
     "mocha": "^6.2.2",
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
@@ -31,6 +31,9 @@
     "semver": "^7.3.2",
     "vuepress": "^1.2.0",
     "warun": "^1.0.0"
+  },
+  "peerDependencies": {
+    "eslint": ">=5"
   },
   "scripts": {
     "prebuild": "npm run -s clean",

--- a/test/pattern-matcher.js
+++ b/test/pattern-matcher.js
@@ -3,7 +3,7 @@ import { PatternMatcher } from "../src/"
 
 const NAMED_CAPTURE_GROUP_SUPPORTED = (() => {
     try {
-        new RegExp("(?<a>)", "u") //eslint-disable-line no-new, prefer-regex-literals, @mysticatea/node/no-unsupported-features/es-syntax
+        new RegExp("(?<a>)", "u") //eslint-disable-line no-new, prefer-regex-literals
         return true
     } catch (_error) {
         return false


### PR DESCRIPTION
ESLint v7.0.0 is [released](https://eslint.org/blog/2020/05/eslint-v7.0.0-released) 🎉

(dev)Dependencies should be compatible with ESLint 7 too before we can merge this one:

- [ ] [`@mysticatea/eslint-plugin`](https://github.com/mysticatea/eslint-plugin/issues/28)
  - [ ]  [PR](https://github.com/mysticatea/eslint-plugin/pull/29)
  - [ ]  Released

---

BREAKING CHANGE: Requires Node@>=10.x

Closes #6