### PR TITLE
Supports for Optional chaining & Nullish coalescing

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "rimraf": "^3.0.0",
     "rollup": "^1.25.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
+    "semver": "^7.3.2",
     "vuepress": "^1.2.0",
     "warun": "^1.0.0"
   },

--- a/src/get-static-value.js
+++ b/src/get-static-value.js
@@ -351,7 +351,8 @@ const operations = Object.freeze({
         if (left != null) {
             if (
                 (node.operator === "||" && Boolean(left.value) === true) ||
-                (node.operator === "&&" && Boolean(left.value) === false)
+                (node.operator === "&&" && Boolean(left.value) === false) ||
+                (node.operator === "??" && left.value != null)
             ) {
                 return left
             }

--- a/src/has-side-effect.js
+++ b/src/has-side-effect.js
@@ -23,6 +23,16 @@ const typeConversionBinaryOps = Object.freeze(
     ])
 )
 const typeConversionUnaryOps = Object.freeze(new Set(["-", "+", "!", "~"]))
+
+/**
+ * Check whether the given value is an ASTNode or not.
+ * @param {any} x The value to check.
+ * @returns {boolean} `true` if the value is an ASTNode.
+ */
+function isNode(x) {
+    return x !== null && typeof x === "object" && typeof x.type === "string"
+}
+
 const visitor = Object.freeze(
     Object.assign(Object.create(null), {
         $visit(node, options, visitorKeys) {
@@ -44,13 +54,16 @@ const visitor = Object.freeze(
                 if (Array.isArray(value)) {
                     for (const element of value) {
                         if (
-                            element &&
+                            isNode(element) &&
                             this.$visit(element, options, visitorKeys)
                         ) {
                             return true
                         }
                     }
-                } else if (value && this.$visit(value, options, visitorKeys)) {
+                } else if (
+                    isNode(value) &&
+                    this.$visit(value, options, visitorKeys)
+                ) {
                     return true
                 }
             }

--- a/src/reference-tracker.js
+++ b/src/reference-tracker.js
@@ -41,6 +41,8 @@ function isPassThrough(node) {
             return true
         case "SequenceExpression":
             return parent.expressions[parent.expressions.length - 1] === node
+        case "ChainExpression":
+            return true
 
         default:
             return false

--- a/test/get-static-value.js
+++ b/test/get-static-value.js
@@ -143,6 +143,66 @@ const aMap = Object.freeze({
             code: "RegExp.$1",
             expected: null,
         },
+        {
+            code: "const a = { b: { c: 42 } }; a?.b?.c",
+            expected: { value: 42 },
+        },
+        {
+            code: "const a = { b: { c: 42 } }; a?.b?.['c']",
+            expected: { value: 42 },
+        },
+        {
+            code: "const a = { b: null }; a?.b?.c",
+            expected: { value: undefined },
+        },
+        {
+            code: "const a = { b: undefined }; a?.b?.c",
+            expected: { value: undefined },
+        },
+        {
+            code: "const a = { b: null }; a?.b?.['c']",
+            expected: { value: undefined },
+        },
+        {
+            code: "const a = null; a?.b?.c",
+            expected: { value: undefined },
+        },
+        {
+            code: "const a = null; a?.b.c",
+            expected: { value: undefined },
+        },
+        {
+            code: "const a = void 0; a?.b.c",
+            expected: { value: undefined },
+        },
+        {
+            code: "const a = { b: { c: 42 } }; (a?.b).c",
+            expected: { value: 42 },
+        },
+        {
+            code: "const a = null; (a?.b).c",
+            expected: null,
+        },
+        {
+            code: "const a = { b: null }; (a?.b).c",
+            expected: null,
+        },
+        {
+            code: "const a = { b: { c: String } }; a?.b?.c?.(42)",
+            expected: { value: "42" },
+        },
+        {
+            code: "const a = null; a?.b?.c?.(42)",
+            expected: { value: undefined },
+        },
+        {
+            code: "const a = { b: { c: String } }; a?.b.c(42)",
+            expected: { value: "42" },
+        },
+        {
+            code: "const a = null; a?.b.c(42)",
+            expected: { value: undefined },
+        },
     ]) {
         it(`should return ${JSON.stringify(expected)} from ${code}`, () => {
             const linter = new eslint.Linter()
@@ -158,7 +218,7 @@ const aMap = Object.freeze({
             }))
             linter.verify(code, {
                 env: { es6: true },
-                parserOptions: { ecmaVersion: 2018 },
+                parserOptions: { ecmaVersion: 2020 },
                 rules: { test: "error" },
             })
 

--- a/test/get-static-value.js
+++ b/test/get-static-value.js
@@ -226,6 +226,14 @@ const aMap = Object.freeze({
                       code: "const a = null; a?.b.c(42)",
                       expected: { value: undefined },
                   },
+                  {
+                      code: "null?.()",
+                      expected: { value: undefined },
+                  },
+                  {
+                      code: "const a = null; a?.()",
+                      expected: { value: undefined },
+                  },
               ]
             : []),
     ]) {

--- a/test/get-static-value.js
+++ b/test/get-static-value.js
@@ -147,6 +147,26 @@ const aMap = Object.freeze({
         ...(semver.gte(eslint.CLIEngine.version, "6.0.0")
             ? [
                   {
+                      code: "const a = null, b = 42; a ?? b",
+                      expected: { value: 42 },
+                  },
+                  {
+                      code: "const a = undefined, b = 42; a ?? b",
+                      expected: { value: 42 },
+                  },
+                  {
+                      code: "const a = false, b = 42; a ?? b",
+                      expected: { value: false },
+                  },
+                  {
+                      code: "const a = 42, b = null; a ?? b",
+                      expected: { value: 42 },
+                  },
+                  {
+                      code: "const a = 42, b = undefined; a ?? b",
+                      expected: { value: 42 },
+                  },
+                  {
                       code: "const a = { b: { c: 42 } }; a?.b?.c",
                       expected: { value: 42 },
                   },

--- a/test/get-static-value.js
+++ b/test/get-static-value.js
@@ -234,6 +234,10 @@ const aMap = Object.freeze({
                       code: "const a = null; a?.()",
                       expected: { value: undefined },
                   },
+                  {
+                      code: "a?.()",
+                      expected: null,
+                  },
               ]
             : []),
     ]) {

--- a/test/get-static-value.js
+++ b/test/get-static-value.js
@@ -1,5 +1,6 @@
 import assert from "assert"
 import eslint from "eslint"
+import semver from "semver"
 import { getStaticValue } from "../src/"
 
 describe("The 'getStaticValue' function", () => {
@@ -143,66 +144,70 @@ const aMap = Object.freeze({
             code: "RegExp.$1",
             expected: null,
         },
-        {
-            code: "const a = { b: { c: 42 } }; a?.b?.c",
-            expected: { value: 42 },
-        },
-        {
-            code: "const a = { b: { c: 42 } }; a?.b?.['c']",
-            expected: { value: 42 },
-        },
-        {
-            code: "const a = { b: null }; a?.b?.c",
-            expected: { value: undefined },
-        },
-        {
-            code: "const a = { b: undefined }; a?.b?.c",
-            expected: { value: undefined },
-        },
-        {
-            code: "const a = { b: null }; a?.b?.['c']",
-            expected: { value: undefined },
-        },
-        {
-            code: "const a = null; a?.b?.c",
-            expected: { value: undefined },
-        },
-        {
-            code: "const a = null; a?.b.c",
-            expected: { value: undefined },
-        },
-        {
-            code: "const a = void 0; a?.b.c",
-            expected: { value: undefined },
-        },
-        {
-            code: "const a = { b: { c: 42 } }; (a?.b).c",
-            expected: { value: 42 },
-        },
-        {
-            code: "const a = null; (a?.b).c",
-            expected: null,
-        },
-        {
-            code: "const a = { b: null }; (a?.b).c",
-            expected: null,
-        },
-        {
-            code: "const a = { b: { c: String } }; a?.b?.c?.(42)",
-            expected: { value: "42" },
-        },
-        {
-            code: "const a = null; a?.b?.c?.(42)",
-            expected: { value: undefined },
-        },
-        {
-            code: "const a = { b: { c: String } }; a?.b.c(42)",
-            expected: { value: "42" },
-        },
-        {
-            code: "const a = null; a?.b.c(42)",
-            expected: { value: undefined },
-        },
+        ...(semver.gte(eslint.CLIEngine.version, "6.0.0")
+            ? [
+                  {
+                      code: "const a = { b: { c: 42 } }; a?.b?.c",
+                      expected: { value: 42 },
+                  },
+                  {
+                      code: "const a = { b: { c: 42 } }; a?.b?.['c']",
+                      expected: { value: 42 },
+                  },
+                  {
+                      code: "const a = { b: null }; a?.b?.c",
+                      expected: { value: undefined },
+                  },
+                  {
+                      code: "const a = { b: undefined }; a?.b?.c",
+                      expected: { value: undefined },
+                  },
+                  {
+                      code: "const a = { b: null }; a?.b?.['c']",
+                      expected: { value: undefined },
+                  },
+                  {
+                      code: "const a = null; a?.b?.c",
+                      expected: { value: undefined },
+                  },
+                  {
+                      code: "const a = null; a?.b.c",
+                      expected: { value: undefined },
+                  },
+                  {
+                      code: "const a = void 0; a?.b.c",
+                      expected: { value: undefined },
+                  },
+                  {
+                      code: "const a = { b: { c: 42 } }; (a?.b).c",
+                      expected: { value: 42 },
+                  },
+                  {
+                      code: "const a = null; (a?.b).c",
+                      expected: null,
+                  },
+                  {
+                      code: "const a = { b: null }; (a?.b).c",
+                      expected: null,
+                  },
+                  {
+                      code: "const a = { b: { c: String } }; a?.b?.c?.(42)",
+                      expected: { value: "42" },
+                  },
+                  {
+                      code: "const a = null; a?.b?.c?.(42)",
+                      expected: { value: undefined },
+                  },
+                  {
+                      code: "const a = { b: { c: String } }; a?.b.c(42)",
+                      expected: { value: "42" },
+                  },
+                  {
+                      code: "const a = null; a?.b.c(42)",
+                      expected: { value: undefined },
+                  },
+              ]
+            : []),
     ]) {
         it(`should return ${JSON.stringify(expected)} from ${code}`, () => {
             const linter = new eslint.Linter()
@@ -218,7 +223,11 @@ const aMap = Object.freeze({
             }))
             linter.verify(code, {
                 env: { es6: true },
-                parserOptions: { ecmaVersion: 2020 },
+                parserOptions: {
+                    ecmaVersion: semver.gte(eslint.CLIEngine.version, "6.0.0")
+                        ? 2020
+                        : 2018,
+                },
                 rules: { test: "error" },
             })
 

--- a/test/has-side-effect.js
+++ b/test/has-side-effect.js
@@ -1,5 +1,6 @@
 import assert from "assert"
 import eslint from "eslint"
+import semver from "semver"
 import dp from "dot-prop"
 import { hasSideEffect } from "../src/"
 
@@ -46,21 +47,29 @@ describe("The 'hasSideEffect' function", () => {
             options: undefined,
             expected: true,
         },
-        {
-            code: "f?.()",
-            options: undefined,
-            expected: true,
-        },
+        ...(semver.gte(eslint.CLIEngine.version, "6.0.0")
+            ? [
+                  {
+                      code: "f?.()",
+                      options: undefined,
+                      expected: true,
+                  },
+              ]
+            : []),
         {
             code: "a + f()",
             options: undefined,
             expected: true,
         },
-        {
-            code: "a + f?.()",
-            options: undefined,
-            expected: true,
-        },
+        ...(semver.gte(eslint.CLIEngine.version, "6.0.0")
+            ? [
+                  {
+                      code: "a + f?.()",
+                      options: undefined,
+                      expected: true,
+                  },
+              ]
+            : []),
         {
             code: "obj.a",
             options: undefined,
@@ -71,16 +80,20 @@ describe("The 'hasSideEffect' function", () => {
             options: { considerGetters: true },
             expected: true,
         },
-        {
-            code: "obj?.a",
-            options: undefined,
-            expected: false,
-        },
-        {
-            code: "obj?.a",
-            options: { considerGetters: true },
-            expected: true,
-        },
+        ...(semver.gte(eslint.CLIEngine.version, "6.0.0")
+            ? [
+                  {
+                      code: "obj?.a",
+                      options: undefined,
+                      expected: false,
+                  },
+                  {
+                      code: "obj?.a",
+                      options: { considerGetters: true },
+                      expected: true,
+                  },
+              ]
+            : []),
         {
             code: "obj[a]",
             options: undefined,
@@ -96,21 +109,25 @@ describe("The 'hasSideEffect' function", () => {
             options: { considerImplicitTypeConversion: true },
             expected: true,
         },
-        {
-            code: "obj?.[a]",
-            options: undefined,
-            expected: false,
-        },
-        {
-            code: "obj?.[a]",
-            options: { considerGetters: true },
-            expected: true,
-        },
-        {
-            code: "obj?.[a]",
-            options: { considerImplicitTypeConversion: true },
-            expected: true,
-        },
+        ...(semver.gte(eslint.CLIEngine.version, "6.0.0")
+            ? [
+                  {
+                      code: "obj?.[a]",
+                      options: undefined,
+                      expected: false,
+                  },
+                  {
+                      code: "obj?.[a]",
+                      options: { considerGetters: true },
+                      expected: true,
+                  },
+                  {
+                      code: "obj?.[a]",
+                      options: { considerImplicitTypeConversion: true },
+                      expected: true,
+                  },
+              ]
+            : []),
         {
             code: "obj[0]",
             options: { considerImplicitTypeConversion: true },
@@ -277,7 +294,11 @@ describe("The 'hasSideEffect' function", () => {
             }))
             const messages = linter.verify(code, {
                 env: { es6: true },
-                parserOptions: { ecmaVersion: 2020 },
+                parserOptions: {
+                    ecmaVersion: semver.gte(eslint.CLIEngine.version, "6.0.0")
+                        ? 2020
+                        : 2018,
+                },
                 rules: { test: "error" },
             })
 

--- a/test/has-side-effect.js
+++ b/test/has-side-effect.js
@@ -47,17 +47,37 @@ describe("The 'hasSideEffect' function", () => {
             expected: true,
         },
         {
+            code: "f?.()",
+            options: undefined,
+            expected: true,
+        },
+        {
             code: "a + f()",
             options: undefined,
             expected: true,
         },
         {
+            code: "a + f?.()",
+            options: undefined,
+            expected: true,
+        },
+        {
             code: "obj.a",
             options: undefined,
             expected: false,
         },
         {
             code: "obj.a",
+            options: { considerGetters: true },
+            expected: true,
+        },
+        {
+            code: "obj?.a",
+            options: undefined,
+            expected: false,
+        },
+        {
+            code: "obj?.a",
             options: { considerGetters: true },
             expected: true,
         },
@@ -73,6 +93,21 @@ describe("The 'hasSideEffect' function", () => {
         },
         {
             code: "obj[a]",
+            options: { considerImplicitTypeConversion: true },
+            expected: true,
+        },
+        {
+            code: "obj?.[a]",
+            options: undefined,
+            expected: false,
+        },
+        {
+            code: "obj?.[a]",
+            options: { considerGetters: true },
+            expected: true,
+        },
+        {
+            code: "obj?.[a]",
             options: { considerImplicitTypeConversion: true },
             expected: true,
         },
@@ -242,7 +277,7 @@ describe("The 'hasSideEffect' function", () => {
             }))
             const messages = linter.verify(code, {
                 env: { es6: true },
-                parserOptions: { ecmaVersion: 2018 },
+                parserOptions: { ecmaVersion: 2020 },
                 rules: { test: "error" },
             })
 

--- a/test/reference-tracker.js
+++ b/test/reference-tracker.js
@@ -1,9 +1,15 @@
 import assert from "assert"
 import eslint from "eslint"
+import semver from "semver"
 import { CALL, CONSTRUCT, ESM, READ, ReferenceTracker } from "../src/"
 
 const config = {
-    parserOptions: { ecmaVersion: 2020, sourceType: "module" },
+    parserOptions: {
+        ecmaVersion: semver.gte(eslint.CLIEngine.version, "6.0.0")
+            ? 2020
+            : 2018,
+        sourceType: "module",
+    },
     globals: { Reflect: false },
     rules: { test: "error" },
 }
@@ -533,11 +539,15 @@ describe("The 'ReferenceTracker' class:", () => {
                     "abc();",
                     "new abc();",
                     "abc.xyz;",
-                    "abc?.xyz;",
-                    "abc?.();",
-                    "abc?.xyz?.();",
-                    "(abc.def).ghi;",
-                    "(abc?.def)?.ghi;",
+                    ...(semver.gte(eslint.CLIEngine.version, "6.0.0")
+                        ? [
+                              "abc?.xyz;",
+                              "abc?.();",
+                              "abc?.xyz?.();",
+                              "(abc.def).ghi;",
+                              "(abc?.def)?.ghi;",
+                          ]
+                        : []),
                 ].join("\n"),
                 traceMap: {
                     abc: {
@@ -573,36 +583,52 @@ describe("The 'ReferenceTracker' class:", () => {
                         type: READ,
                         info: 4,
                     },
-                    {
-                        node: { type: "MemberExpression", optional: true },
-                        path: ["abc", "xyz"],
-                        type: READ,
-                        info: 4,
-                    },
-                    {
-                        node: { type: "CallExpression", optional: true },
-                        path: ["abc"],
-                        type: CALL,
-                        info: 2,
-                    },
-                    {
-                        node: { type: "MemberExpression", optional: true },
-                        path: ["abc", "xyz"],
-                        type: READ,
-                        info: 4,
-                    },
-                    {
-                        node: { type: "MemberExpression" },
-                        path: ["abc", "def", "ghi"],
-                        type: READ,
-                        info: 5,
-                    },
-                    {
-                        node: { type: "MemberExpression", optional: true },
-                        path: ["abc", "def", "ghi"],
-                        type: READ,
-                        info: 5,
-                    },
+                    ...(semver.gte(eslint.CLIEngine.version, "6.0.0")
+                        ? [
+                              {
+                                  node: {
+                                      type: "MemberExpression",
+                                      optional: true,
+                                  },
+                                  path: ["abc", "xyz"],
+                                  type: READ,
+                                  info: 4,
+                              },
+                              {
+                                  node: {
+                                      type: "CallExpression",
+                                      optional: true,
+                                  },
+                                  path: ["abc"],
+                                  type: CALL,
+                                  info: 2,
+                              },
+                              {
+                                  node: {
+                                      type: "MemberExpression",
+                                      optional: true,
+                                  },
+                                  path: ["abc", "xyz"],
+                                  type: READ,
+                                  info: 4,
+                              },
+                              {
+                                  node: { type: "MemberExpression" },
+                                  path: ["abc", "def", "ghi"],
+                                  type: READ,
+                                  info: 5,
+                              },
+                              {
+                                  node: {
+                                      type: "MemberExpression",
+                                      optional: true,
+                                  },
+                                  path: ["abc", "def", "ghi"],
+                                  type: READ,
+                                  info: 5,
+                              },
+                          ]
+                        : []),
                 ],
             },
             {

--- a/test/reference-tracker.js
+++ b/test/reference-tracker.js
@@ -3,7 +3,7 @@ import eslint from "eslint"
 import { CALL, CONSTRUCT, ESM, READ, ReferenceTracker } from "../src/"
 
 const config = {
-    parserOptions: { ecmaVersion: 2018, sourceType: "module" },
+    parserOptions: { ecmaVersion: 2020, sourceType: "module" },
     globals: { Reflect: false },
     rules: { test: "error" },
 }
@@ -504,7 +504,14 @@ describe("The 'ReferenceTracker' class:", () => {
                         actual = Array.from(
                             tracker.iterateGlobalReferences(traceMap)
                         ).map(x =>
-                            Object.assign(x, { node: { type: x.node.type } })
+                            Object.assign(x, {
+                                node: Object.assign(
+                                    { type: x.node.type },
+                                    x.node.optional
+                                        ? { optional: x.node.optional }
+                                        : {}
+                                ),
+                            })
                         )
                     },
                 }))
@@ -526,6 +533,11 @@ describe("The 'ReferenceTracker' class:", () => {
                     "abc();",
                     "new abc();",
                     "abc.xyz;",
+                    "abc?.xyz;",
+                    "abc?.();",
+                    "abc?.xyz?.();",
+                    "(abc.def).ghi;",
+                    "(abc?.def)?.ghi;",
                 ].join("\n"),
                 traceMap: {
                     abc: {
@@ -533,6 +545,7 @@ describe("The 'ReferenceTracker' class:", () => {
                         [CALL]: 2,
                         [CONSTRUCT]: 3,
                         xyz: { [READ]: 4 },
+                        def: { ghi: { [READ]: 5 } },
                     },
                 },
                 expected: [
@@ -559,6 +572,36 @@ describe("The 'ReferenceTracker' class:", () => {
                         path: ["abc", "xyz"],
                         type: READ,
                         info: 4,
+                    },
+                    {
+                        node: { type: "MemberExpression", optional: true },
+                        path: ["abc", "xyz"],
+                        type: READ,
+                        info: 4,
+                    },
+                    {
+                        node: { type: "CallExpression", optional: true },
+                        path: ["abc"],
+                        type: CALL,
+                        info: 2,
+                    },
+                    {
+                        node: { type: "MemberExpression", optional: true },
+                        path: ["abc", "xyz"],
+                        type: READ,
+                        info: 4,
+                    },
+                    {
+                        node: { type: "MemberExpression" },
+                        path: ["abc", "def", "ghi"],
+                        type: READ,
+                        info: 5,
+                    },
+                    {
+                        node: { type: "MemberExpression", optional: true },
+                        path: ["abc", "def", "ghi"],
+                        type: READ,
+                        info: 5,
                     },
                 ],
             },
@@ -613,7 +656,14 @@ describe("The 'ReferenceTracker' class:", () => {
                         actual = Array.from(
                             tracker.iterateCjsReferences(traceMap)
                         ).map(x =>
-                            Object.assign(x, { node: { type: x.node.type } })
+                            Object.assign(x, {
+                                node: Object.assign(
+                                    { type: x.node.type },
+                                    x.node.optional
+                                        ? { optional: x.node.optional }
+                                        : {}
+                                ),
+                            })
                         )
                     },
                 }))
@@ -888,7 +938,14 @@ describe("The 'ReferenceTracker' class:", () => {
                         actual = Array.from(
                             tracker.iterateEsmReferences(traceMap)
                         ).map(x =>
-                            Object.assign(x, { node: { type: x.node.type } })
+                            Object.assign(x, {
+                                node: Object.assign(
+                                    { type: x.node.type },
+                                    x.node.optional
+                                        ? { optional: x.node.optional }
+                                        : {}
+                                ),
+                            })
                         )
                     },
                 }))


### PR DESCRIPTION
- Updated ReferenceTracker to parse optional chaining.
- Updated getStaticValue to parse optional chaining and nullish coalescing.
- Fixed hasSideEffect infinite loop.
  It will continue to traverse the `type` string on nodes that do not exist in `"eslint-visitor-keys"`, resulting in an infinite loop.