### PR TITLE
Fix #12 by not resolving static value of `Symbol()`

### DIFF
--- a/src/get-static-value.js
+++ b/src/get-static-value.js
@@ -101,7 +101,6 @@ const callAllowed = new Set(
         String.fromCharCode,
         String.fromCodePoint,
         String.raw,
-        Symbol,
         Symbol.for,
         Symbol.keyFor,
         unescape,

--- a/test/get-static-value.js
+++ b/test/get-static-value.js
@@ -74,6 +74,10 @@ describe("The 'getStaticValue' function", () => {
             expected: { value: Symbol.iterator },
         },
         { code: "Symbol[iterator]", expected: null },
+        {
+            code: "const symbol = Symbol(); (symbol === symbol)",
+            expected: null,
+        },
         { code: "Object.freeze", expected: { value: Object.freeze } },
         { code: "Object.xxx", expected: { value: undefined } },
         { code: "new Array(2)", expected: null },


### PR DESCRIPTION
See title.

Closes #12.

I don't think this is a breaking change, since the public API doesn't make specific claims about what will and won't return non-`null` from `getStaticValue()`.