### PR TITLE
Fix `isParenthesized()` check on `CatchClause.param`

### DIFF
--- a/src/is-parenthesized.js
+++ b/src/is-parenthesized.js
@@ -92,7 +92,11 @@ export function isParenthesized(
         sourceCode = nodeOrSourceCode
     }
 
-    if (node == null) {
+    if (
+        node == null ||
+        // `CatchClause.param` can't be parenthesized, example `try {} catch (error) {}`
+        (node.parent.type === "CatchClause" && node.parent.param === node)
+    ) {
         return false
     }
 

--- a/test/is-parenthesized.js
+++ b/test/is-parenthesized.js
@@ -203,6 +203,12 @@ describe("The 'isParenthesized' function", () => {
                 "body.0.object": true,
             },
         },
+        {
+            code: "try {} catch (a) {}",
+            expected: {
+                "body.0.handler.param": false,
+            },
+        },
     ]) {
         describe(`on the code \`${code}\``, () => {
             for (const key of Object.keys(expected)) {


### PR DESCRIPTION
Fixes #15