### PR TITLE
Fix `isParenthesized` crash on `Program`

### DIFF
--- a/src/is-parenthesized.js
+++ b/src/is-parenthesized.js
@@ -94,10 +94,10 @@ export function isParenthesized(
 
     if (
         node == null ||
+        // `Program` can't be parenthesized
+        node.parent == null ||
         // `CatchClause.param` can't be parenthesized, example `try {} catch (error) {}`
-        (node.parent &&
-            node.parent.type === "CatchClause" &&
-            node.parent.param === node)
+        (node.parent.type === "CatchClause" && node.parent.param === node)
     ) {
         return false
     }

--- a/src/is-parenthesized.js
+++ b/src/is-parenthesized.js
@@ -95,7 +95,9 @@ export function isParenthesized(
     if (
         node == null ||
         // `CatchClause.param` can't be parenthesized, example `try {} catch (error) {}`
-        (node.parent.type === "CatchClause" && node.parent.param === node)
+        (node.parent &&
+            node.parent.type === "CatchClause" &&
+            node.parent.param === node)
     ) {
         return false
     }

--- a/test/is-parenthesized.js
+++ b/test/is-parenthesized.js
@@ -209,6 +209,12 @@ describe("The 'isParenthesized' function", () => {
                 "body.0.handler.param": false,
             },
         },
+        {
+            code: "foo;",
+            expected: {
+                "body.0.parent": false,
+            },
+        },
     ]) {
         describe(`on the code \`${code}\``, () => {
             for (const key of Object.keys(expected)) {


### PR DESCRIPTION
I can't run test locally, but should be fixed.