### PR TITLE
Allow simple function expressions in `getStaticValue`

### DIFF
--- a/test/get-static-value.js
+++ b/test/get-static-value.js
@@ -111,7 +111,8 @@ describe("The 'getStaticValue' function", () => {
         { code: "void a.b", expected: { value: undefined } },
         { code: "+a", expected: null },
         { code: "delete a.b", expected: null },
-        { code: "!function(){ return true }", expected: null },
+        { code: "!function(){ return true }", expected: { value: false } },
+        { code: "!function(){ someFunc(); }", expected: null },
         { code: "'' + Symbol()", expected: null },
         {
             code: `const eventName = "click"
@@ -129,6 +130,13 @@ const aMap = Object.freeze({
             code: 'new Function("return process.env.npm_name")()',
             expected: null,
         },
+        { code: "(() => 5)()", expected: { value: 5 } },
+        { code: "(() => { return 5; })()", expected: { value: 5 } },
+        { code: "(function() { return 5; })()", expected: { value: 5 } },
+        { code: "(function*() { return 5; })()", expected: null },
+        { code: "(async function() { return 5; })()", expected: null },
+        { code: "(async () => { return 5; })()", expected: null },
+        { code: "((a) => a + 1)(4)", expected: null },
         {
             code: '({}.constructor.constructor("return process.env.npm_name")())',
             expected: null,


### PR DESCRIPTION
This allows simple function expressions (e.g. `() => 4`) in `getStaticValue`.

Only functions that are not `async`, not generators, and have no parameters are supported. The function body must be empty or only have a simple `return` statement and the value of the return statement must be static. 
We can safely create functions under those conditions.

