### PR TITLE
feat: support ESLint 8.x

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - name: Install Packages
         run: npm install
       - name: Lint
@@ -28,33 +28,36 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        eslint: [7]
-        node: [14]
+        eslint: [8]
+        node: [16]
         include:
           # On other platforms
-          - eslint: 7
-            node: 14
+          - eslint: 8
+            node: 16
             os: windows-latest
-          - eslint: 7
-            node: 14
+          - eslint: 8
+            node: 16
             os: macos-latest
           # On old Node.js versions
-          - eslint: 7
+          - eslint: 8
+            node: 14
+            os: ubuntu-latest
+          - eslint: 8
             node: 12
             os: ubuntu-latest
-          - eslint: 7
-            node: 10
-            os: ubuntu-latest
           # On old ESLint versions
+          - eslint: 7
+            node: 16
+            os: ubuntu-latest
           - eslint: 6
-            node: 14
+            node: 16
             os: ubuntu-latest
           - eslint: 5
-            node: 14
+            node: 16
             os: ubuntu-latest
           # On the minimum supported ESLint/Node.js version
           - eslint: 5
-            node: 10
+            node: 12.22.0
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "description": "Utilities for ESLint plugins.",
   "engines": {
-    "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
   },
   "sideEffects": false,
   "main": "index",
@@ -19,15 +19,15 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "eslint-visitor-keys": "^2.0.0"
+    "eslint-visitor-keys": "^3.0.0"
   },
   "devDependencies": {
     "@mysticatea/eslint-plugin": "^13.0.0",
     "codecov": "^3.6.1",
     "dot-prop": "^4.2.0",
-    "eslint": "^7.24.0",
+    "eslint": "^8.0.0",
     "esm": "^3.2.25",
-    "espree": "github:eslint/espree#1c744b3a602b783926344811a9459b92afe57444",
+    "espree": "^9.0.0",
     "mocha": "^6.2.2",
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
@@ -41,7 +41,7 @@
     "warun": "^1.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=5"
+    "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "scripts": {
     "prebuild": "npm run -s clean",


### PR DESCRIPTION
ESLint v8.0.0 is [released](https://eslint.org/blog/2021/10/eslint-v8.0.0-released) 🎉

devDependency compatibility with ESLint 8:

- [ ] [`@mysticatea/eslint-plugin`](https://github.com/mysticatea/eslint-plugin) (https://github.com/mysticatea/eslint-plugin/issues/31)
  - [ ] https://github.com/mysticatea/eslint-plugin/pull/29
  - [ ] https://github.com/mysticatea/eslint-plugin/pull/32
  - [ ] Release

---

BREAKING CHANGE: Requires Node@^12.22.0 || ^14.17.0 || >=16.0.0

Closes #33