### PR TITLE
fix: add Non-empty judgment

### DIFF
--- a/src/reference-tracker.js
+++ b/src/reference-tracker.js
@@ -394,23 +394,28 @@ export class ReferenceTracker {
                     info: nextTraceMap[READ],
                 }
             }
-            yield* this._iterateVariableReferences(
-                findVariable(this.globalScope, specifierNode.local),
-                path,
-                nextTraceMap,
-                false,
-            )
-
+            const variable = findVariable(this.globalScope, specifierNode.local)
+            if (variable != null) {
+                yield* this._iterateVariableReferences(
+                    variable,
+                    path,
+                    nextTraceMap,
+                    false,
+                )
+            }
             return
         }
 
         if (type === "ImportNamespaceSpecifier") {
-            yield* this._iterateVariableReferences(
-                findVariable(this.globalScope, specifierNode.local),
-                path,
-                traceMap,
-                false,
-            )
+            const variable = findVariable(this.globalScope, specifierNode.local)
+            if (variable != null) {
+                yield* this._iterateVariableReferences(
+                    findVariable(this.globalScope, specifierNode.local),
+                    path,
+                    traceMap,
+                    false,
+                )
+            }
             return
         }
 


### PR DESCRIPTION
I added a non-empty judgment to the variable that may cause a TypeError（
`TypeError: Cannot read property 'references' of null`
） in _**_iterateVariableReferences**_
`for (const reference of variable.references) {`