### PR TITLE
Chore: use explicit path (extension)

### DIFF
--- a/src/find-variable.js
+++ b/src/find-variable.js
@@ -1,4 +1,4 @@
-import { getInnermostScope } from "./get-innermost-scope"
+import { getInnermostScope } from "./get-innermost-scope.js";
 
 /**
  * Find the variable of a given name.

--- a/src/get-function-head-location.js
+++ b/src/get-function-head-location.js
@@ -1,4 +1,4 @@
-import { isArrowToken, isOpeningParenToken } from "./token-predicate"
+import { isArrowToken, isOpeningParenToken } from "./token-predicate.js"
 
 /**
  * Get the `(` token of the given function node.

--- a/src/get-function-name-with-kind.js
+++ b/src/get-function-name-with-kind.js
@@ -1,4 +1,4 @@
-import { getPropertyName } from "./get-property-name"
+import { getPropertyName } from "./get-property-name.js"
 
 /**
  * Get the name and kind of the given function node.

--- a/src/get-property-name.js
+++ b/src/get-property-name.js
@@ -1,4 +1,4 @@
-import { getStringIfConstant } from "./get-string-if-constant"
+import { getStringIfConstant } from "./get-string-if-constant.js"
 
 /**
  * Get the property name from a MemberExpression node or a Property node.

--- a/src/get-static-value.js
+++ b/src/get-static-value.js
@@ -1,6 +1,6 @@
 /* globals globalThis, global, self, window */
 
-import { findVariable } from "./find-variable"
+import { findVariable } from "./find-variable.js"
 
 const globalObject =
     typeof globalThis !== "undefined"

--- a/src/get-string-if-constant.js
+++ b/src/get-string-if-constant.js
@@ -1,4 +1,4 @@
-import { getStaticValue } from "./get-static-value"
+import { getStaticValue } from "./get-static-value.js"
 
 /**
  * Get the value of a given node if it's a literal or a template literal.

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
-import { findVariable } from "./find-variable"
-import { getFunctionHeadLocation } from "./get-function-head-location"
-import { getFunctionNameWithKind } from "./get-function-name-with-kind"
-import { getInnermostScope } from "./get-innermost-scope"
-import { getPropertyName } from "./get-property-name"
-import { getStaticValue } from "./get-static-value"
-import { getStringIfConstant } from "./get-string-if-constant"
-import { hasSideEffect } from "./has-side-effect"
-import { isParenthesized } from "./is-parenthesized"
-import { PatternMatcher } from "./pattern-matcher"
+import { findVariable } from "./find-variable.js"
+import { getFunctionHeadLocation } from "./get-function-head-location.js"
+import { getFunctionNameWithKind } from "./get-function-name-with-kind.js"
+import { getInnermostScope } from "./get-innermost-scope.js"
+import { getPropertyName } from "./get-property-name.js"
+import { getStaticValue } from "./get-static-value.js"
+import { getStringIfConstant } from "./get-string-if-constant.js"
+import { hasSideEffect } from "./has-side-effect.js"
+import { isParenthesized } from "./is-parenthesized.js"
+import { PatternMatcher } from "./pattern-matcher.js"
 import {
     CALL,
     CONSTRUCT,
@@ -37,8 +37,8 @@ import {
     isOpeningBraceToken,
     isOpeningBracketToken,
     isOpeningParenToken,
-    isSemicolonToken,
-} from "./token-predicate"
+    isSemicolonToken
+} from "./token-predicate.js"
 
 export default {
     CALL,

--- a/src/is-parenthesized.js
+++ b/src/is-parenthesized.js
@@ -1,4 +1,4 @@
-import { isClosingParenToken, isOpeningParenToken } from "./token-predicate"
+import { isClosingParenToken, isOpeningParenToken } from "./token-predicate.js"
 
 /**
  * Get the left parenthesis of the parent node syntax if it exists.

--- a/src/reference-tracker.js
+++ b/src/reference-tracker.js
@@ -1,6 +1,6 @@
-import { findVariable } from "./find-variable"
-import { getPropertyName } from "./get-property-name"
-import { getStringIfConstant } from "./get-string-if-constant"
+import { findVariable } from "./find-variable.js"
+import { getPropertyName } from "./get-property-name.js"
+import { getStringIfConstant } from "./get-string-if-constant.js"
 
 const IMPORT_TYPE = /^(?:Import|Export(?:All|Default|Named))Declaration$/u
 const has = Function.call.bind(Object.hasOwnProperty)

--- a/test/find-variable.js
+++ b/test/find-variable.js
@@ -1,6 +1,6 @@
 import assert from "assert"
 import eslint from "eslint"
-import { findVariable } from "../src/"
+import { findVariable } from "../src/index.js"
 
 describe("The 'findVariable' function", () => {
     function getVariable(code, selector, withString = null) {

--- a/test/get-function-head-location.js
+++ b/test/get-function-head-location.js
@@ -1,7 +1,7 @@
 import assert from "assert"
 import eslint from "eslint"
 import semver from "semver"
-import { getFunctionHeadLocation } from "../src/"
+import { getFunctionHeadLocation } from "../src/index.js"
 
 describe("The 'getFunctionHeadLocation' function", () => {
     const expectedResults = {

--- a/test/get-function-name-with-kind.js
+++ b/test/get-function-name-with-kind.js
@@ -1,7 +1,7 @@
 import assert from "assert"
 import eslint from "eslint"
 import semver from "semver"
-import { getFunctionNameWithKind } from "../src/"
+import { getFunctionNameWithKind } from "../src/index.js"
 
 describe("The 'getFunctionNameWithKind' function", () => {
     const expectedResults = {

--- a/test/get-innermost-scope.js
+++ b/test/get-innermost-scope.js
@@ -1,6 +1,6 @@
 import assert from "assert"
 import eslint from "eslint"
-import { getInnermostScope } from "../src/"
+import { getInnermostScope } from "../src/index.js"
 
 describe("The 'getInnermostScope' function", () => {
     let i = 0

--- a/test/get-property-name.js
+++ b/test/get-property-name.js
@@ -1,7 +1,7 @@
 import assert from "assert"
 import eslint from "eslint"
 import semver from "semver"
-import { getPropertyName } from "../src/"
+import { getPropertyName } from "../src/index.js"
 
 describe("The 'getPropertyName' function", () => {
     for (const { code, expected } of [

--- a/test/get-static-value.js
+++ b/test/get-static-value.js
@@ -1,7 +1,7 @@
 import assert from "assert"
 import eslint from "eslint"
 import semver from "semver"
-import { getStaticValue } from "../src/"
+import { getStaticValue } from "../src/index.js"
 
 describe("The 'getStaticValue' function", () => {
     for (const { code, expected, noScope = false } of [

--- a/test/get-string-if-constant.js
+++ b/test/get-string-if-constant.js
@@ -1,6 +1,6 @@
 import assert from "assert"
 import eslint from "eslint"
-import { getStringIfConstant } from "../src/"
+import { getStringIfConstant } from "../src/index.js"
 
 describe("The 'getStringIfConstant' function", () => {
     for (const { code, expected } of [

--- a/test/has-side-effect.js
+++ b/test/has-side-effect.js
@@ -2,7 +2,7 @@ import assert from "assert"
 import eslint from "eslint"
 import semver from "semver"
 import dp from "dot-prop"
-import { hasSideEffect } from "../src/"
+import { hasSideEffect } from "../src/index.js"
 
 describe("The 'hasSideEffect' function", () => {
     for (const { code, key = "body.0.expression", options, expected } of [

--- a/test/is-parenthesized.js
+++ b/test/is-parenthesized.js
@@ -1,7 +1,7 @@
 import assert from "assert"
 import dotProp from "dot-prop"
 import eslint from "eslint"
-import { isParenthesized } from "../src/"
+import { isParenthesized } from "../src/index.js"
 
 describe("The 'isParenthesized' function", () => {
     for (const { code, expected } of [

--- a/test/pattern-matcher.js
+++ b/test/pattern-matcher.js
@@ -1,5 +1,5 @@
 import assert from "assert"
-import { PatternMatcher } from "../src/"
+import { PatternMatcher } from "../src/index.js"
 
 const NAMED_CAPTURE_GROUP_SUPPORTED = (() => {
     try {

--- a/test/reference-tracker.js
+++ b/test/reference-tracker.js
@@ -1,7 +1,7 @@
 import assert from "assert"
 import eslint from "eslint"
 import semver from "semver"
-import { CALL, CONSTRUCT, ESM, READ, ReferenceTracker } from "../src/"
+import { CALL, CONSTRUCT, ESM, READ, ReferenceTracker } from "../src/index.js"
 
 const config = {
     parserOptions: {

--- a/test/token-predicate.js
+++ b/test/token-predicate.js
@@ -21,8 +21,8 @@ import {
     isOpeningBraceToken,
     isOpeningBracketToken,
     isOpeningParenToken,
-    isSemicolonToken,
-} from "../src/"
+    isSemicolonToken
+} from "../src/index.js"
 
 describe("The predicate functions for tokens", () => {
     for (const { positive, negative, patterns } of [


### PR DESCRIPTION
This could theoretically work without the need of compiling things, just need to add the extension

> Mandatory file extensions#
> A file extension must be provided when using the import keyword to resolve relative or absolute specifiers. Directory indexes (e.g. './startup/index.js') must also be fully specified.
> 
> This behavior matches how import behaves in browser environments, assuming a typically configured server.

ref: https://nodejs.org/dist/latest-v17.x/docs/api/esm.html#mandatory-file-extensions